### PR TITLE
chore: bump jinja2 version

### DIFF
--- a/files/palmnode/ansible/requirements.txt
+++ b/files/palmnode/ansible/requirements.txt
@@ -2,6 +2,6 @@ ansible==2.10.7
 boto3==1.17.53
 boto==2.49.0
 botocore==1.20.54
-jinja2==2.11.3
+jinja2==3.1.1
 pyyaml==5.4.1
 requests==2.25.1


### PR DESCRIPTION
Repo was failing to deploy because the `jinja2` version was out of date, this lead to the `besu` user never being created so the `setup.sh` script was unable to run successfully